### PR TITLE
Add :input selector

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -533,6 +533,8 @@ func (p *parser) parsePseudoclassSelector() (Selector, error) {
 		return onlyChildSelector(false), nil
 	case "only-of-type":
 		return onlyChildSelector(true), nil
+	case "input":
+		return inputSelector, nil
 	case "empty":
 		return emptyElementSelector, nil
 	}

--- a/selector.go
+++ b/selector.go
@@ -430,6 +430,11 @@ func onlyChildSelector(ofType bool) Selector {
 	}
 }
 
+// inputSelector is a Selector that matches input, select, textarea and button elements.
+func inputSelector(n *html.Node) bool {
+	return n.Type == html.ElementNode && (n.Data == "input" || n.Data == "select" || n.Data == "textarea" || n.Data == "button")
+}
+
 // emptyElementSelector is a Selector that matches empty elements.
 func emptyElementSelector(n *html.Node) bool {
 	if n.Type != html.ElementNode {

--- a/selector_test.go
+++ b/selector_test.go
@@ -493,6 +493,28 @@ var selectorTests = []selectorTest{
 			`<a id="a3" href="https://www.google.com/news">`,
 		},
 	},
+	{
+		`<form>
+			<label>Username <input type="text" name="username" /></label>
+			<label>Password <input type="password" name="password" /></label>
+			<label>Country
+				<select name="country">
+					<option value="ca">Canada</option>
+					<option value="us">United States</option>
+				</select>
+			</label>
+			<label>Bio <textarea name="bio"></textarea></label>
+			<button>Sign up</button>
+		</form>`,
+		`:input`,
+		[]string{
+			`<input type="text" name="username">`,
+			`<input type="password" name="password">`,
+			`<select name="country">`,
+			`<textarea name="bio">`,
+			`<button>`,
+		},
+	},
 }
 
 func TestSelectors(t *testing.T) {


### PR DESCRIPTION
This adds `:input` selector that matches `input`, `select`, `textarea` and `button` elements like Sizzle (https://github.com/jquery/sizzle/blob/a6ca3e9919c7a77001bdec01b3579e4bafd73a84/src/sizzle.js#L129)

@andybalholm are you okay with this?