### PR TITLE
use html.Render() to replace nodeString()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 [![](https://travis-ci.org/andybalholm/cascadia.svg)](https://travis-ci.org/andybalholm/cascadia)
 
 The Cascadia package implements CSS selectors for use with the parse trees produced by the html package.
+
+To test CSS selectors without writing Go code, check out [cascadia](https://github.com/suntong/cascadia) the command line tool, a thin wrapper around this package.

--- a/selector_test.go
+++ b/selector_test.go
@@ -1,6 +1,7 @@
 package cascadia
 
 import (
+	"bytes"
 	"strings"
 	"testing"
 
@@ -31,52 +32,52 @@ var selectorTests = []selectorTest{
 		`<body><address>This address...</address></body>`,
 		"address",
 		[]string{
-			"<address>",
+			"<address>This address...</address>",
 		},
 	},
 	{
 		`<html><head></head><body></body></html>`,
 		"*",
 		[]string{
-			"",
-			"<html>",
-			"<head>",
-			"<body>",
+			"<html><head></head><body></body></html>",
+			"<html><head></head><body></body></html>",
+			"<head></head>",
+			"<body></body>",
 		},
 	},
 	{
 		`<p id="foo"><p id="bar">`,
 		"#foo",
 		[]string{
-			`<p id="foo">`,
+			`<p id="foo"></p>`,
 		},
 	},
 	{
 		`<ul><li id="t1"><p id="t1">`,
 		"li#t1",
 		[]string{
-			`<li id="t1">`,
+			`<li id="t1"><p id="t1"></p></li>`,
 		},
 	},
 	{
 		`<ol><li id="t4"><li id="t44">`,
 		"*#t4",
 		[]string{
-			`<li id="t4">`,
+			`<li id="t4"></li>`,
 		},
 	},
 	{
 		`<ul><li class="t1"><li class="t2">`,
 		".t1",
 		[]string{
-			`<li class="t1">`,
+			`<li class="t1"></li>`,
 		},
 	},
 	{
 		`<p class="t1 t2">`,
 		"p.t1",
 		[]string{
-			`<p class="t1 t2">`,
+			`<p class="t1 t2"></p>`,
 		},
 	},
 	{
@@ -93,36 +94,36 @@ var selectorTests = []selectorTest{
 		`<p class="t1 t2">`,
 		"p.t1.t2",
 		[]string{
-			`<p class="t1 t2">`,
+			`<p class="t1 t2"></p>`,
 		},
 	},
 	{
 		`<p><p title="title">`,
 		"p[title]",
 		[]string{
-			`<p title="title">`,
+			`<p title="title"></p>`,
 		},
 	},
 	{
 		`<address><address title="foo"><address title="bar">`,
 		`address[title="foo"]`,
 		[]string{
-			`<address title="foo">`,
+			`<address title="foo"><address title="bar"></address></address>`,
 		},
 	},
 	{
 		`<address><address title="foo"><address title="bar">`,
 		`address[title!="foo"]`,
 		[]string{
-			`<address>`,
-			`<address title="bar">`,
+			`<address><address title="foo"><address title="bar"></address></address></address>`,
+			`<address title="bar"></address>`,
 		},
 	},
 	{
 		`<p title="tot foo bar">`,
 		`[    	title        ~=       foo    ]`,
 		[]string{
-			`<p title="tot foo bar">`,
+			`<p title="tot foo bar"></p>`,
 		},
 	},
 	{
@@ -134,29 +135,29 @@ var selectorTests = []selectorTest{
 		`<p lang="en"><p lang="en-gb"><p lang="enough"><p lang="fr-en">`,
 		`[lang|="en"]`,
 		[]string{
-			`<p lang="en">`,
-			`<p lang="en-gb">`,
+			`<p lang="en"></p>`,
+			`<p lang="en-gb"></p>`,
 		},
 	},
 	{
 		`<p title="foobar"><p title="barfoo">`,
 		`[title^="foo"]`,
 		[]string{
-			`<p title="foobar">`,
+			`<p title="foobar"></p>`,
 		},
 	},
 	{
 		`<p title="foobar"><p title="barfoo">`,
 		`[title$="bar"]`,
 		[]string{
-			`<p title="foobar">`,
+			`<p title="foobar"></p>`,
 		},
 	},
 	{
 		`<p title="foobarufoo">`,
 		`[title*="bar"]`,
 		[]string{
-			`<p title="foobarufoo">`,
+			`<p title="foobarufoo"></p>`,
 		},
 	},
 	{
@@ -168,173 +169,173 @@ var selectorTests = []selectorTest{
 		`<div class="t3">`,
 		`div:not(.t1)`,
 		[]string{
-			`<div class="t3">`,
+			`<div class="t3"></div>`,
 		},
 	},
 	{
 		`<div><div class="t2"><div class="t3">`,
 		`div:not([class="t2"])`,
 		[]string{
-			`<div>`,
-			`<div class="t3">`,
+			`<div><div class="t2"><div class="t3"></div></div></div>`,
+			`<div class="t3"></div>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3></ol>`,
 		`li:nth-child(odd)`,
 		[]string{
-			`<li id="1">`,
-			`<li id="3">`,
+			`<li id="1"></li>`,
+			`<li id="3"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3></ol>`,
 		`li:nth-child(even)`,
 		[]string{
-			`<li id="2">`,
+			`<li id="2"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3></ol>`,
 		`li:nth-child(-n+2)`,
 		[]string{
-			`<li id="1">`,
-			`<li id="2">`,
+			`<li id="1"></li>`,
+			`<li id="2"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3></ol>`,
 		`li:nth-child(3n+1)`,
 		[]string{
-			`<li id="1">`,
+			`<li id="1"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
 		`li:nth-last-child(odd)`,
 		[]string{
-			`<li id="2">`,
-			`<li id="4">`,
+			`<li id="2"></li>`,
+			`<li id="4"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
 		`li:nth-last-child(even)`,
 		[]string{
-			`<li id="1">`,
-			`<li id="3">`,
+			`<li id="1"></li>`,
+			`<li id="3"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
 		`li:nth-last-child(-n+2)`,
 		[]string{
-			`<li id="3">`,
-			`<li id="4">`,
+			`<li id="3"></li>`,
+			`<li id="4"></li>`,
 		},
 	},
 	{
 		`<ol><li id=1><li id=2><li id=3><li id=4></ol>`,
 		`li:nth-last-child(3n+1)`,
 		[]string{
-			`<li id="1">`,
-			`<li id="4">`,
+			`<li id="1"></li>`,
+			`<li id="4"></li>`,
 		},
 	},
 	{
 		`<p>some text <span id="1">and a span</span><span id="2"> and another</span></p>`,
 		`span:first-child`,
 		[]string{
-			`<span id="1">`,
+			`<span id="1">and a span</span>`,
 		},
 	},
 	{
 		`<span>a span</span> and some text`,
 		`span:last-child`,
 		[]string{
-			`<span>`,
+			`<span>a span</span>`,
 		},
 	},
 	{
 		`<address></address><p id=1><p id=2>`,
 		`p:nth-of-type(2)`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<address></address><p id=1><p id=2></p><a>`,
 		`p:nth-last-of-type(2)`,
 		[]string{
-			`<p id="1">`,
+			`<p id="1"></p>`,
 		},
 	},
 	{
 		`<address></address><p id=1><p id=2></p><a>`,
 		`p:last-of-type`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<address></address><p id=1><p id=2></p><a>`,
 		`p:first-of-type`,
 		[]string{
-			`<p id="1">`,
+			`<p id="1"></p>`,
 		},
 	},
 	{
 		`<div><p id="1"></p><a></a></div><div><p id="2"></p></div>`,
 		`p:only-child`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<div><p id="1"></p><a></a></div><div><p id="2"></p><p id="3"></p></div>`,
 		`p:only-of-type`,
 		[]string{
-			`<p id="1">`,
+			`<p id="1"></p>`,
 		},
 	},
 	{
 		`<p id="1"><!-- --><p id="2">Hello<p id="3"><span>`,
 		`:empty`,
 		[]string{
-			`<head>`,
-			`<p id="1">`,
-			`<span>`,
+			`<head></head>`,
+			`<p id="1"><!-- --></p>`,
+			`<span></span>`,
 		},
 	},
 	{
 		`<div><p id="1"><table><tr><td><p id="2"></table></div><p id="3">`,
 		`div p`,
 		[]string{
-			`<p id="1">`,
-			`<p id="2">`,
+			`<p id="1"><table><tbody><tr><td><p id="2"></p></td></tr></tbody></table></p>`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<div><p id="1"><table><tr><td><p id="2"></table></div><p id="3">`,
 		`div table p`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<div><p id="1"><div><p id="2"></div><table><tr><td><p id="3"></table></div>`,
 		`div > p`,
 		[]string{
-			`<p id="1">`,
-			`<p id="2">`,
+			`<p id="1"></p>`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<p id="1"><p id="2"></p><address></address><p id="3">`,
 		`p ~ p`,
 		[]string{
-			`<p id="2">`,
-			`<p id="3">`,
+			`<p id="2"></p>`,
+			`<p id="3"></p>`,
 		},
 	},
 	{
@@ -343,30 +344,30 @@ var selectorTests = []selectorTest{
 		 <p id="2"></p><address></address><p id="3">`,
 		`p + p`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<ul><li></li><li></li></ul><p>`,
 		`li, p`,
 		[]string{
-			"<li>",
-			"<li>",
-			"<p>",
+			"<li></li>",
+			"<li></li>",
+			"<p></p>",
 		},
 	},
 	{
 		`<p id="1"><p id="2"></p><address></address><p id="3">`,
 		`p +/*This is a comment*/ p`,
 		[]string{
-			`<p id="2">`,
+			`<p id="2"></p>`,
 		},
 	},
 	{
 		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
 		`p:contains("that wraps")`,
 		[]string{
-			`<p>`,
+			`<p>Text block that <span>wraps inner text</span> and continues</p>`,
 		},
 	},
 	{
@@ -378,21 +379,21 @@ var selectorTests = []selectorTest{
 		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
 		`:containsOwn("inner")`,
 		[]string{
-			`<span>`,
+			`<span>wraps inner text</span>`,
 		},
 	},
 	{
 		`<p>Text block that <span>wraps inner text</span> and continues</p>`,
 		`p:containsOwn("block")`,
 		[]string{
-			`<p>`,
+			`<p>Text block that <span>wraps inner text</span> and continues</p>`,
 		},
 	},
 	{
 		`<div id="d1"><p id="p1"><span>text content</span></p></div><div id="d2"/>`,
 		`div:has(#p1)`,
 		[]string{
-			`<div id="d1">`,
+			`<div id="d1"><p id="p1"><span>text content</span></p></div>`,
 		},
 	},
 	{
@@ -400,7 +401,7 @@ var selectorTests = []selectorTest{
 		<div id="d2"><p>contents <em>2</em></p></div>`,
 		`div:has(:containsOwn("2"))`,
 		[]string{
-			`<div id="d2">`,
+			`<div id="d2"><p>contents <em>2</em></p></div>`,
 		},
 	},
 	{
@@ -408,8 +409,8 @@ var selectorTests = []selectorTest{
 		<div id="d2"><p id="p2">contents <em>2</em></p></div></body>`,
 		`body :has(:containsOwn("2"))`,
 		[]string{
-			`<div id="d2">`,
-			`<p id="p2">`,
+			`<div id="d2"><p id="p2">contents <em>2</em></p></div>`,
+			`<p id="p2">contents <em>2</em></p>`,
 		},
 	},
 	{
@@ -417,96 +418,96 @@ var selectorTests = []selectorTest{
 		<div id="d2"><p id="p2">contents <em>2</em></p></div></body>`,
 		`body :haschild(:containsOwn("2"))`,
 		[]string{
-			`<p id="p2">`,
+			`<p id="p2">contents <em>2</em></p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches([\d])`,
 		[]string{
-			`<p id="p1">`,
-			`<p id="p3">`,
+			`<p id="p1">0123456789</p>`,
+			`<p id="p3">0123ABCD</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches([a-z])`,
 		[]string{
-			`<p id="p2">`,
+			`<p id="p2">abcdef</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches([a-zA-Z])`,
 		[]string{
-			`<p id="p2">`,
-			`<p id="p3">`,
+			`<p id="p2">abcdef</p>`,
+			`<p id="p3">0123ABCD</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches([^\d])`,
 		[]string{
-			`<p id="p2">`,
-			`<p id="p3">`,
+			`<p id="p2">abcdef</p>`,
+			`<p id="p3">0123ABCD</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches(^(0|a))`,
 		[]string{
-			`<p id="p1">`,
-			`<p id="p2">`,
-			`<p id="p3">`,
+			`<p id="p1">0123456789</p>`,
+			`<p id="p2">abcdef</p>`,
+			`<p id="p3">0123ABCD</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:matches(^\d+$)`,
 		[]string{
-			`<p id="p1">`,
+			`<p id="p1">0123456789</p>`,
 		},
 	},
 	{
 		`<p id="p1">0123456789</p><p id="p2">abcdef</p><p id="p3">0123ABCD</p>`,
 		`p:not(:matches(^\d+$))`,
 		[]string{
-			`<p id="p2">`,
-			`<p id="p3">`,
+			`<p id="p2">abcdef</p>`,
+			`<p id="p3">0123ABCD</p>`,
 		},
 	},
 	{
 		`<div><p id="p1">01234<em>567</em>89</p><div>`,
 		`div :matchesOwn(^\d+$)`,
 		[]string{
-			`<p id="p1">`,
-			`<em>`,
+			`<p id="p1">01234<em>567</em>89</p>`,
+			`<em>567</em>`,
 		},
 	},
 	{
 		`<ul>
-			<li><a id="a1" href="http://www.google.com/finance"/>
-			<li><a id="a2" href="http://finance.yahoo.com/"/>
+			<li><a id="a1" href="http://www.google.com/finance"></a>
+			<li><a id="a2" href="http://finance.yahoo.com/"></a>
 			<li><a id="a2" href="http://finance.untrusted.com/"/>
 			<li><a id="a3" href="https://www.google.com/news"/>
 			<li><a id="a4" href="http://news.yahoo.com"/>
 		</ul>`,
 		`[href#=(fina)]:not([href#=(\/\/[^\/]+untrusted)])`,
 		[]string{
-			`<a id="a1" href="http://www.google.com/finance">`,
-			`<a id="a2" href="http://finance.yahoo.com/">`,
+			`<a id="a1" href="http://www.google.com/finance"></a>`,
+			`<a id="a2" href="http://finance.yahoo.com/"></a>`,
 		},
 	},
 	{
 		`<ul>
 			<li><a id="a1" href="http://www.google.com/finance"/>
 			<li><a id="a2" href="http://finance.yahoo.com/"/>
-			<li><a id="a3" href="https://www.google.com/news"/>
+			<li><a id="a3" href="https://www.google.com/news"></a>
 			<li><a id="a4" href="http://news.yahoo.com"/>
 		</ul>`,
 		`[href#=(^https:\/\/[^\/]*\/?news)]`,
 		[]string{
-			`<a id="a3" href="https://www.google.com/news">`,
+			`<a id="a3" href="https://www.google.com/news"></a>`,
 		},
 	},
 	{
@@ -524,11 +525,14 @@ var selectorTests = []selectorTest{
 		</form>`,
 		`:input`,
 		[]string{
-			`<input type="text" name="username">`,
-			`<input type="password" name="password">`,
-			`<select name="country">`,
-			`<textarea name="bio">`,
-			`<button>`,
+			`<input type="text" name="username"/>`,
+			`<input type="password" name="password"/>`,
+			`<select name="country">
+					<option value="ca">Canada</option>
+					<option value="us">United States</option>
+				</select>`,
+			`<textarea name="bio"></textarea>`,
+			`<button>Sign up</button>`,
 		},
 	},
 }
@@ -554,7 +558,9 @@ func TestSelectors(t *testing.T) {
 		}
 
 		for i, m := range matches {
-			got := nodeString(m)
+			buf := bytes.NewBufferString("")
+			html.Render(buf, m)
+			got := buf.String()
 			if got != test.results[i] {
 				t.Errorf("wanted %s, got %s instead", test.results[i], got)
 			}
@@ -566,7 +572,9 @@ func TestSelectors(t *testing.T) {
 				t.Errorf("MatchFirst: want nil, got %s", nodeString(firstMatch))
 			}
 		} else {
-			got := nodeString(firstMatch)
+			buf := bytes.NewBufferString("")
+			html.Render(buf, firstMatch)
+			got := buf.String()
 			if got != test.results[0] {
 				t.Errorf("MatchFirst: want %s, got %s", test.results[0], got)
 			}

--- a/selector_test.go
+++ b/selector_test.go
@@ -161,6 +161,20 @@ var selectorTests = []selectorTest{
 		},
 	},
 	{
+		`<input type="radio" name="Sex" value="F"/>`,
+		`input[name=Sex][value=F]`,
+		[]string{
+			`<input type="radio" name="Sex" value="F"/>`,
+		},
+	},
+	{
+		`<table border="0" cellpadding="0" cellspacing="0" style="table-layout: fixed; width: 100%; border: 0 dashed; border-color: #FFFFFF"><tr style="height:64px">aaa</tr></table>`,
+		`table[border="0"][cellpadding="0"][cellspacing="0"]`,
+		[]string{
+			`<table border="0" cellpadding="0" cellspacing="0" style="table-layout: fixed; width: 100%; border: 0 dashed; border-color: #FFFFFF"><tbody><tr style="height:64px"></tr></tbody></table>`,
+		},
+	},
+	{
 		`<p class="t1 t2">`,
 		".t1:not(.t2)",
 		[]string{},

--- a/selector_test.go
+++ b/selector_test.go
@@ -14,17 +14,9 @@ type selectorTest struct {
 }
 
 func nodeString(n *html.Node) string {
-	switch n.Type {
-	case html.TextNode:
-		return n.Data
-	case html.ElementNode:
-		return html.Token{
-			Type: html.StartTagToken,
-			Data: n.Data,
-			Attr: n.Attr,
-		}.String()
-	}
-	return ""
+	buf := bytes.NewBufferString("")
+	html.Render(buf, n)
+	return buf.String()
 }
 
 var selectorTests = []selectorTest{
@@ -572,9 +564,7 @@ func TestSelectors(t *testing.T) {
 		}
 
 		for i, m := range matches {
-			buf := bytes.NewBufferString("")
-			html.Render(buf, m)
-			got := buf.String()
+			got := nodeString(m)
 			if got != test.results[i] {
 				t.Errorf("wanted %s, got %s instead", test.results[i], got)
 			}
@@ -586,9 +576,7 @@ func TestSelectors(t *testing.T) {
 				t.Errorf("MatchFirst: want nil, got %s", nodeString(firstMatch))
 			}
 		} else {
-			buf := bytes.NewBufferString("")
-			html.Render(buf, firstMatch)
-			got := buf.String()
+			got := nodeString(firstMatch)
 			if got != test.results[0] {
 				t.Errorf("MatchFirst: want %s, got %s", test.results[0], got)
 			}


### PR DESCRIPTION
- [*] use html.Render() to replace nodeString(). Closed #23.
- [+] add two more multiple attribute selector test cases

You may want to take a closer look at the following code,

```
	{
		`<ul>
			<li><a id="a1" href="http://www.google.com/finance"></a>
			<li><a id="a2" href="http://finance.yahoo.com/"></a>
			<li><a id="a2" href="http://finance.untrusted.com/"/>
			<li><a id="a3" href="https://www.google.com/news"/>
			<li><a id="a4" href="http://news.yahoo.com"/>
		</ul>`,
		`[href#=(fina)]:not([href#=(\/\/[^\/]+untrusted)])`,
		[]string{
			`<a id="a1" href="http://www.google.com/finance"></a>`,
			`<a id="a2" href="http://finance.yahoo.com/"></a>`,
		},

```

and make some changes, and of course you may leave it as-is as well. 
