### PR TITLE
universal selector should match only ElementNodes

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -752,7 +752,7 @@ loop:
 
 	if result == nil {
 		result = func(n *html.Node) bool {
-			return true
+			return n.Type == html.ElementNode
 		}
 	}
 

--- a/selector_test.go
+++ b/selector_test.go
@@ -28,10 +28,18 @@ var selectorTests = []selectorTest{
 		},
 	},
 	{
+		`<!-- comment --><html><head></head><body>text</body></html>`,
+		"*",
+		[]string{
+			"<html><head></head><body>text</body></html>",
+			"<head></head>",
+			"<body>text</body>",
+		},
+	},
+	{
 		`<html><head></head><body></body></html>`,
 		"*",
 		[]string{
-			"<html><head></head><body></body></html>",
 			"<html><head></head><body></body></html>",
 			"<head></head>",
 			"<body></body>",
@@ -559,26 +567,26 @@ func TestSelectors(t *testing.T) {
 
 		matches := s.MatchAll(doc)
 		if len(matches) != len(test.results) {
-			t.Errorf("wanted %d elements, got %d instead", len(test.results), len(matches))
+			t.Errorf("selector %s wanted %d elements, got %d instead", test.selector, len(test.results), len(matches))
 			continue
 		}
 
 		for i, m := range matches {
 			got := nodeString(m)
 			if got != test.results[i] {
-				t.Errorf("wanted %s, got %s instead", test.results[i], got)
+				t.Errorf("selector %s wanted %s, got %s instead", test.selector, test.results[i], got)
 			}
 		}
 
 		firstMatch := s.MatchFirst(doc)
 		if len(test.results) == 0 {
 			if firstMatch != nil {
-				t.Errorf("MatchFirst: want nil, got %s", nodeString(firstMatch))
+				t.Errorf("MatchFirst: selector %s want nil, got %s", test.selector, nodeString(firstMatch))
 			}
 		} else {
 			got := nodeString(firstMatch)
 			if got != test.results[0] {
-				t.Errorf("MatchFirst: want %s, got %s", test.results[0], got)
+				t.Errorf("MatchFirst: selector %s want %s, got %s", test.selector, test.results[0], got)
 			}
 		}
 	}


### PR DESCRIPTION
Per the spec [1] the universal selector should match only element nodes. This PR omits non-element nodes. 

This behavior is consistent with other contemporary selector implementations. From within Chrome, for example, if an html file is opened containing

```
<!-- comment --><html><head></head><body>text</body></html>
```

And from within the console the following selector is evaluated: 

```
$$('*') 
```

The result is 3 nodes:
```
Array[3]
0: html
1: head
2: body
length: 3
```

[1] https://www.w3.org/TR/css3-selectors/#universal-selector