### PR TITLE
don't match on blank attribute selectors

### DIFF
--- a/selector.go
+++ b/selector.go
@@ -228,6 +228,9 @@ func attributeDashmatchSelector(key, val string) Selector {
 func attributePrefixSelector(key, val string) Selector {
 	return attributeSelector(key,
 		func(s string) bool {
+			if strings.TrimSpace(s) == "" {
+				return false
+			}
 			return strings.HasPrefix(s, val)
 		})
 }
@@ -237,6 +240,9 @@ func attributePrefixSelector(key, val string) Selector {
 func attributeSuffixSelector(key, val string) Selector {
 	return attributeSelector(key,
 		func(s string) bool {
+			if strings.TrimSpace(s) == "" {
+				return false
+			}
 			return strings.HasSuffix(s, val)
 		})
 }
@@ -246,6 +252,9 @@ func attributeSuffixSelector(key, val string) Selector {
 func attributeSubstringSelector(key, val string) Selector {
 	return attributeSelector(key,
 		func(s string) bool {
+			if strings.TrimSpace(s) == "" {
+				return false
+			}
 			return strings.Contains(s, val)
 		})
 }

--- a/selector_test.go
+++ b/selector_test.go
@@ -153,6 +153,36 @@ var selectorTests = []selectorTest{
 		},
 	},
 	{
+		`<p class=" ">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class$=" "]`,
+		[]string{},
+	},
+	{
+		`<p class="">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class$=""]`,
+		[]string{},
+	},
+	{
+		`<p class=" ">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class^=" "]`,
+		[]string{},
+	},
+	{
+		`<p class="">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class^=""]`,
+		[]string{},
+	},
+	{
+		`<p class=" ">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class*=" "]`,
+		[]string{},
+	},
+	{
+		`<p class="">This text should be green.</p><p>This text should be green.</p>`,
+		`p[class*=""]`,
+		[]string{},
+	},
+	{
 		`<input type="radio" name="Sex" value="F"/>`,
 		`input[name=Sex][value=F]`,
 		[]string{


### PR DESCRIPTION
The CSS3 spec describes suffix/prefix/substring attribute matching behavior for empty strings to explicitly not match. See:

- https://www.w3.org/Style/CSS/Test/CSS3/Selectors/current/html/full/flat/css3-modsel-184a.html
- https://www.w3.org/Style/CSS/Test/CSS3/Selectors/current/html/full/flat/css3-modsel-184b.html
- https://www.w3.org/Style/CSS/Test/CSS3/Selectors/current/html/full/flat/css3-modsel-184c.html