### PR TITLE
Add specificity support

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -423,7 +423,7 @@ var errExpectedClosingParenthesis = errors.New("expected ')' but didn't find it"
 var errUnmatchedParenthesis = errors.New("unmatched '('")
 
 // parsePseudoclassSelector parses a pseudoclass selector like :not(p)
-func (p *parser) parsePseudoclassSelector() (out Matcher, err error) {
+func (p *parser) parsePseudoclassSelector() (out Sel, err error) {
 	if p.i >= len(p.s) {
 		return nil, fmt.Errorf("expected pseudoclass selector (:pseudoclass), found EOF instead")
 	}
@@ -685,8 +685,8 @@ invalid:
 
 // parseSimpleSelectorSequence parses a selector sequence that applies to
 // a single element.
-func (p *parser) parseSimpleSelectorSequence() (Matcher, error) {
-	var selectors []Matcher
+func (p *parser) parseSimpleSelectorSequence() (Sel, error) {
+	var selectors []Sel
 
 	if p.i >= len(p.s) {
 		return nil, errors.New("expected selector, found EOF instead")
@@ -709,7 +709,7 @@ func (p *parser) parseSimpleSelectorSequence() (Matcher, error) {
 loop:
 	for p.i < len(p.s) {
 		var (
-			ns  Matcher
+			ns  Sel
 			err error
 		)
 		switch p.s[p.i] {

--- a/selector.go
+++ b/selector.go
@@ -732,7 +732,7 @@ func (t compoundSelector) Match(n *html.Node) bool {
 func (s compoundSelector) Specificity() Specificity {
 	var out Specificity
 	for _, sel := range s.selectors {
-		out.Add(sel.Specificity())
+		out = out.Add(sel.Specificity())
 	}
 	return out
 }
@@ -813,7 +813,7 @@ func siblingMatch(s1, s2 Matcher, adjacent bool, n *html.Node) bool {
 func (s combinedSelector) Specificity() Specificity {
 	spec := s.first.Specificity()
 	if s.second != nil {
-		spec.Add(s.second.Specificity())
+		spec = spec.Add(s.second.Specificity())
 	}
 	return spec
 }

--- a/specificity.go
+++ b/specificity.go
@@ -1,0 +1,25 @@
+package cascadia
+
+// Specificity is the CSS specificity as defined in
+// https://www.w3.org/TR/selectors/#specificity-rules
+// with the convention Specificity = [A,B,C].
+type Specificity [3]int
+
+// returns `true` if s < other (strictly), false otherwise
+func (s Specificity) Less(other Specificity) bool {
+	for i := range s {
+		if s[i] < other[i] {
+			return true
+		}
+		if s[i] > other[i] {
+			return false
+		}
+	}
+	return false
+}
+
+func (s *Specificity) Add(other Specificity) {
+	for i, sp := range other {
+		s[i] += sp
+	}
+}

--- a/specificity.go
+++ b/specificity.go
@@ -18,8 +18,9 @@ func (s Specificity) Less(other Specificity) bool {
 	return false
 }
 
-func (s *Specificity) Add(other Specificity) {
+func (s Specificity) Add(other Specificity) Specificity {
 	for i, sp := range other {
 		s[i] += sp
 	}
+	return s
 }

--- a/specificity_test.go
+++ b/specificity_test.go
@@ -1,0 +1,107 @@
+package cascadia
+
+import (
+	"strings"
+	"testing"
+
+	"golang.org/x/net/html"
+)
+
+type testSpec struct {
+	// html, css selector
+	HTML, selector string
+	// correct specificity
+	spec Specificity
+}
+
+var testsSpecificity = []testSpec{
+	{
+		HTML:     `<html><body><div><div><a href="http://www.foo.com"></a></div></div></body></html>`,
+		selector: ":not(em, strong#foo)",
+		spec:     Specificity{1, 0, 1},
+	},
+	{
+		HTML:     `<html><body><div><div><a href="http://www.foo.com"></a></div></div></body></html>`,
+		selector: "*",
+		spec:     Specificity{0, 0, 0},
+	},
+	{
+		HTML:     `<html><body><div><div><ul></ul></div></div></body></html>`,
+		selector: "ul",
+		spec:     Specificity{0, 0, 1},
+	},
+	{
+		HTML:     `<html><body><div><ul><li></li></ul></div></body></html>`,
+		selector: "ul li",
+		spec:     Specificity{0, 0, 2},
+	},
+	{
+		HTML:     `<html><body><div><ul><ol></ol><li></li></ul></div></body></html>`,
+		selector: "ul ol+li",
+		spec:     Specificity{0, 0, 3},
+	},
+	{
+		HTML:     `<html><body><div><ul><h1></h1><li rel="up"></li></ul></div></body></html>`,
+		selector: "H1 + *[REL=up] ",
+		spec:     Specificity{0, 1, 1},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li class="red"></li></ol></ul></body></html>`,
+		selector: "UL OL LI.red",
+		spec:     Specificity{0, 1, 3},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li class="red level"></li></ol></ul></body></html>`,
+		selector: "LI.red.level",
+		spec:     Specificity{0, 2, 1},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li id="x34y"></li></ol></ul></body></html>`,
+		selector: "#x34y",
+		spec:     Specificity{1, 0, 0},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li id="s12"></li></ol></ul></body></html>`,
+		selector: "#s12:not(FOO)",
+		spec:     Specificity{1, 0, 1},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li id="s12"></li></ol></ul></body></html>`,
+		selector: "#s12:not(FOO)",
+		spec:     Specificity{1, 0, 1},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li id="s12"></li></ol></ul></body></html>`,
+		selector: "#s12:empty",
+		spec:     Specificity{1, 1, 0},
+	},
+	{
+		HTML:     `<html><body><ul><ol><li id="s12"></li></ol></ul></body></html>`,
+		selector: "#s12:only-child",
+		spec:     Specificity{1, 1, 0},
+	},
+}
+
+func TestSpecificity(t *testing.T) {
+	for _, test := range testsSpecificity {
+		s, err := Parse(test.selector)
+		if err != nil {
+			t.Fatalf("error compiling %q: %s", test.selector, err)
+		}
+
+		doc, err := html.Parse(strings.NewReader(test.HTML))
+		if err != nil {
+			t.Fatalf("error parsing %q: %s", test.HTML, err)
+		}
+		body := doc.FirstChild.LastChild
+		testNode := body.FirstChild.FirstChild.LastChild
+		if !s.Match(testNode) {
+			t.Errorf("%s didn't match (html tree : \n %s) \n", test.selector, nodeString(doc))
+			continue
+		}
+		gotSpec := s.Specificity()
+		if gotSpec != test.spec {
+			t.Errorf("wrong specificity : expected %v, got %v", test.spec, gotSpec)
+		}
+	}
+}


### PR DESCRIPTION
As discussed previously, this PR adds support for specificity.
The method MatchWithSpecificity (for SelectorGroup)  is not yet implemented.
(Some tests for pseudo classes are missing.)