### PR TITLE
Fix unicode escape

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -33,7 +33,7 @@ func (p *parser) parseEscape() (result string, err error) {
 	case hexDigit(c):
 		// unicode escape (hex)
 		var i int
-		for i = start; i < p.i+6 && i < len(p.s) && hexDigit(p.s[i]); i++ {
+		for i = start; i < start+6 && i < len(p.s) && hexDigit(p.s[i]); i++ {
 			// empty
 		}
 		v, _ := strconv.ParseUint(p.s[start:i], 16, 21)

--- a/parser_test.go
+++ b/parser_test.go
@@ -5,11 +5,12 @@ import (
 )
 
 var identifierTests = map[string]string{
-	"x":         "x",
-	"96":        "",
-	"-x":        "-x",
-	`r\e9 sumé`: "résumé",
-	`a\"b`:      `a"b`,
+	"x":             "x",
+	"96":            "",
+	"-x":            "-x",
+	`r\e9 sumé`:     "résumé",
+	`r\0000e9 sumé`: "résumé",
+	`a\"b`:          `a"b`,
 }
 
 func TestParseIdentifier(t *testing.T) {
@@ -45,12 +46,13 @@ func TestParseIdentifier(t *testing.T) {
 }
 
 var stringTests = map[string]string{
-	`"x"`:         "x",
-	`'x'`:         "x",
-	`'x`:          "",
-	"'x\\\r\nx'":  "xx",
-	`"r\e9 sumé"`: "résumé",
-	`"a\"b"`:      `a"b`,
+	`"x"`:             "x",
+	`'x'`:             "x",
+	`'x`:              "",
+	"'x\\\r\nx'":      "xx",
+	`"r\e9 sumé"`:     "résumé",
+	`"r\0000e9 sumé"`: "résumé",
+	`"a\"b"`:          `a"b`,
 }
 
 func TestParseString(t *testing.T) {


### PR DESCRIPTION
Hi,

This PR fix a corner case when parsing unicode espace : if I'm not mistaken, the stop index should be start + 6 (that is p.i + 7), to allow 6 chars unicode sequences.