### PR TITLE
Fix :nth-child selectors pseudo-classes for the root element

### DIFF
--- a/pseudo_classes.go
+++ b/pseudo_classes.go
@@ -184,10 +184,6 @@ func nthChildMatch(a, b int, last, ofType bool, n *html.Node) bool {
 		return false
 	}
 
-	if parent.Type == html.DocumentNode {
-		return false
-	}
-
 	i := -1
 	count := 0
 	for c := parent.FirstChild; c != nil; c = c.NextSibling {
@@ -232,10 +228,6 @@ func simpleNthChildMatch(b int, ofType bool, n *html.Node) bool {
 		return false
 	}
 
-	if parent.Type == html.DocumentNode {
-		return false
-	}
-
 	count := 0
 	for c := parent.FirstChild; c != nil; c = c.NextSibling {
 		if c.Type != html.ElementNode || (ofType && c.Data != n.Data) {
@@ -261,10 +253,6 @@ func simpleNthLastChildMatch(b int, ofType bool, n *html.Node) bool {
 
 	parent := n.Parent
 	if parent == nil {
-		return false
-	}
-
-	if parent.Type == html.DocumentNode {
 		return false
 	}
 
@@ -298,10 +286,6 @@ func (s onlyChildPseudoClassSelector) Match(n *html.Node) bool {
 
 	parent := n.Parent
 	if parent == nil {
-		return false
-	}
-
-	if parent.Type == html.DocumentNode {
 		return false
 	}
 

--- a/selector_test.go
+++ b/selector_test.go
@@ -713,13 +713,24 @@ var selectorTests = []selectorTest{
 	},
 	{
 		`<html><head></head><body></body></html>`,
+		"html:nth-child(1)",
+		[]string{
+			"<html><head></head><body></body></html>",
+		},
+	},
+	{
+		`<html><head></head><body></body></html>`,
 		"*:root:first-child",
-		[]string{},
+		[]string{
+			`<html><head></head><body></body></html>`,
+		},
 	},
 	{
 		`<html><head></head><body></body></html>`,
 		"*:root:nth-child(1)",
-		[]string{},
+		[]string{
+			`<html><head></head><body></body></html>`,
+		},
 	},
 	{
 		`<html><head></head><body><a href="http://www.foo.com"></a></body></html>`,


### PR DESCRIPTION
`:nth-child` and related selectors should work on the root element. They do in browsers, and according to CSS selector spec, "It is not required to have a parent."[1].

[1] https://drafts.csswg.org/selectors-3/#nth-child-pseudo