### PR TITLE
allow css selectors to have prefixes of multiple dashes.

### DIFF
--- a/parser_test.go
+++ b/parser_test.go
@@ -17,7 +17,7 @@ var identifierTests = map[string]string{
 func TestParseIdentifier(t *testing.T) {
 	for source, want := range identifierTests {
 		p := &parser{s: source}
-		got, err := p.parseIdentifier()
+		got, err := p.parseIdentifier(nil)
 		if err != nil {
 			if want == "" {
 				// It was supposed to be an error.

--- a/selector_test.go
+++ b/selector_test.go
@@ -117,6 +117,13 @@ var selectorTests = []selectorTest{
 		},
 	},
 	{
+		`<p class="--t1 --t2">`,
+		"p.--t1",
+		[]string{
+			`<p class="--t1 --t2"></p>`,
+		},
+	},
+	{
 		`<p><p title="title">`,
 		"p[title]",
 		[]string{


### PR DESCRIPTION
Hi I wanted to give it a try, please have a look.

The idea here is to enable different prefix parser functions per identifier type.


If this is about to get merged, please add the label 'hacktoberfest-accepted'

fixes #47