### PR TITLE
Updated go.mod dependencies per Snyk alert

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,4 @@ module github.com/andybalholm/cascadia
 
 go 1.16
 
-require golang.org/x/net v0.0.0-20210916014120-12bc252f5db8
+require golang.org/x/net v0.0.0-20211216030914-fe4d6282115f

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8 h1:/6y1LfuqNuQdHAm0jjtPtgRcxIxjVZgm5OTu8/QhZvk=
 golang.org/x/net v0.0.0-20210916014120-12bc252f5db8/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f h1:hEYJvxw1lSnWIl8X9ofsYMklzaDs90JI2az5YMd4fPM=
+golang.org/x/net v0.0.0-20211216030914-fe4d6282115f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=


### PR DESCRIPTION
Signed-off-by: Jauder Ho <jauderho@users.noreply.github.com>

Snyk identified cascadia as needing to have an updated `golang.org/x/net/http2`. See https://security.snyk.io/vuln/SNYK-GOLANG-GOLANGORGXNETHTTP2-2313688

This PR just bumps the x/net version.