### PR TITLE
perf: avoid buffer allocation in :empty matcher

### DIFF
--- a/pseudo_classes.go
+++ b/pseudo_classes.go
@@ -327,7 +327,7 @@ func (s emptyElementPseudoClassSelector) Match(n *html.Node) bool {
 		case html.ElementNode:
 			return false
 		case html.TextNode:
-			if strings.TrimSpace(nodeText(c)) == "" {
+			if strings.TrimSpace(c.Data) == "" {
 				continue
 			} else {
 				return false


### PR DESCRIPTION
emptyElementPseudoClassSelector.Match called nodeText(c) on a child that is already a TextNode. nodeText allocates a bytes.Buffer and copies the string, but for a TextNode the result is identical to c.Data.

Use c.Data directly to skip the allocation.

div:empty on shakespeare.html: 50µs -> 8.2µs/op (-84%), 23344 B/op -> 0, 486 allocs/op -> 0.